### PR TITLE
Add install to CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,11 @@ target_link_libraries(dmac
 # )
 
 ## Mark executables and/or libraries for installation
+
+install(TARGETS dmac dmac
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
+
 # install(TARGETS beginner_tutorials beginner_tutorials_node
 #   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 #   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}


### PR DESCRIPTION
Add dmac to the install space. Otherwise it is not possible to use "source install/setup.bash" instead of "source devel/setup.bash".